### PR TITLE
CODA-168 - Reduce neurons in XOR

### DIFF
--- a/network_test.go
+++ b/network_test.go
@@ -20,12 +20,7 @@ func TestNetwork(t *testing.T) {
 							BiasWeight: rand.Float64(),
 						},
 						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64()},
-							Bias:       1,
-							BiasWeight: rand.Float64(),
-						},
-						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64()},
+							Weight:     []float64{-rand.Float64(), -rand.Float64()},
 							Bias:       1,
 							BiasWeight: rand.Float64(),
 						},
@@ -34,7 +29,7 @@ func TestNetwork(t *testing.T) {
 				&Layer{
 					neurons: []*Neuron{
 						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64(), rand.Float64()},
+							Weight:     []float64{rand.Float64(), -rand.Float64()},
 							Bias:       1,
 							BiasWeight: rand.Float64(),
 						},
@@ -43,7 +38,7 @@ func TestNetwork(t *testing.T) {
 			},
 		}
 
-		for i := 0; i < 2000; i++ {
+		for i := 0; i < 20000; i++ {
 			network.Think([]float64{0, 0})
 			network.BackPropagate([]float64{0})
 
@@ -89,17 +84,12 @@ func TestNetwork(t *testing.T) {
 				&Layer{
 					neurons: []*Neuron{
 						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64(), rand.Float64(), rand.Float64()},
+							Weight:     []float64{-rand.Float64(), rand.Float64(), -rand.Float64(), rand.Float64()},
 							Bias:       1,
 							BiasWeight: rand.Float64(),
 						},
 						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64(), rand.Float64(), rand.Float64()},
-							Bias:       1,
-							BiasWeight: rand.Float64(),
-						},
-						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64(), rand.Float64(), rand.Float64()},
+							Weight:     []float64{rand.Float64(), -rand.Float64(), rand.Float64(), -rand.Float64()},
 							Bias:       1,
 							BiasWeight: rand.Float64(),
 						},
@@ -108,12 +98,12 @@ func TestNetwork(t *testing.T) {
 				&Layer{
 					neurons: []*Neuron{
 						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64(), rand.Float64()},
+							Weight:     []float64{-rand.Float64(), rand.Float64()},
 							Bias:       1,
 							BiasWeight: rand.Float64(),
 						},
 						&Neuron{
-							Weight:     []float64{rand.Float64(), rand.Float64(), rand.Float64()},
+							Weight:     []float64{rand.Float64(), -rand.Float64()},
 							Bias:       1,
 							BiasWeight: rand.Float64(),
 						},

--- a/transfer.go
+++ b/transfer.go
@@ -16,8 +16,7 @@ func SigmoidDerivative(netSignal float64) float64 {
 
 // Tanh - activation function
 func Tanh(netSignal float64) float64 {
-	normalized := math.Min(netSignal, 2)
-	return (math.Exp(normalized) - math.Exp(-normalized)) / (math.Exp(normalized) + math.Exp(-normalized))
+	return (math.Exp(netSignal) - math.Exp(-netSignal)) / (math.Exp(netSignal) + math.Exp(-netSignal))
 }
 
 // TanhDerivative - activation function

--- a/utils.go
+++ b/utils.go
@@ -12,7 +12,7 @@ func DebugNetwork(network Network, epoch int, outputs ...[]float64) {
 
 	for lk, l := range network.layers {
 		for nk, n := range l.neurons {
-			fmt.Printf("N[%d,%d]\tI=%f\tW=%f\tE=%f\n", lk, nk, n.Input, n.Weight, n.Error)
+			fmt.Printf("N[%d,%d]\tI=%f\tW=%f\tBW=%f\tE=%f\n", lk, nk, n.Input, n.Weight, n.BiasWeight, n.Error)
 		}
 	}
 


### PR DESCRIPTION
**Business justification:** https://trello.com/c/ismWGZkD/168-coda-168-reduce-neurons-in-xor

**Description:** Break initial symmetry by adding negative initial weights, this way we can get rid of one redundant neuron.